### PR TITLE
Fix AS and AM (detected as a country) on search

### DIFF
--- a/fetchmirrors.sh
+++ b/fetchmirrors.sh
@@ -138,12 +138,12 @@ search() {
 			
 		for i in $(echo "$code") ; do
 			case "$i" in
-				1)	# Set query to all mirrors
+				1|AM)	# Set query to all mirrors
 					country="All"
 					query="https://www.archlinux.org/mirrorlist/all/"
 					break
 				;;
-				2)	# Set query to all https mirrors
+				2|AS)	# Set query to all https mirrors
 					country="All HTTPS"
 					query="https://www.archlinux.org/mirrorlist/all/https/"
 					break


### PR DESCRIPTION
AS and AM input were detected as a country and the URL was ?country=AS, what's a 404.
Now they're detected correctly.